### PR TITLE
Update node-7.1.0.sh added additional 'sed'

### DIFF
--- a/android/build/node-v7.1.0.sh
+++ b/android/build/node-v7.1.0.sh
@@ -24,6 +24,9 @@ sed -i "s/uv__getiovmax()/1024/" $MEDIR/../$ME/deps/uv/src/unix/stream.c
 sed -i "s/UV__POLLIN/1/g" $MEDIR/../$ME/deps/uv/src/unix/core.c
 sed -i "s/UV__POLLOUT/4/g" $MEDIR/../$ME/deps/uv/src/unix/core.c
 
+# see # see https://github.com/nodejs/node/issues/3074
+sed -i 's/#define HAVE_GETSERVBYPORT_R 1/#undef HAVE_GETSERVBYPORT_R/' deps/cares/config/android/ares_config.h 
+
 export CC="$CC --sysroot=$ANDROID -I$ANDROID/include -L$ANDROID/lib"
 export CXX="$CXX --sysroot=$ANDROID -I$ANDROID/include -L$ANDROID/lib"
 export CFLAGS="$CFLAGS $CXXCONFIGFLAGS $CXXLIBPLUS $PIEFLAG"


### PR DESCRIPTION
Thanks for your build script. It was one of the few working ones I found. It compiled Node `7.10.1` (using ndk r15 latest) successfully.
It does not compile Node as shared library unfortunately, and no v8.x version (mkpeephole issues).

One addition to the script that was necessary however, was undefining `HAVE_GETSERVBYPORT_R`

(taken from @gartner build script in https://github.com/nodejs/node/issues/10341#issuecomment-271040889)